### PR TITLE
refactor: remove default carousel padding

### DIFF
--- a/components/carousel-static/carousel-static.tsx
+++ b/components/carousel-static/carousel-static.tsx
@@ -25,14 +25,14 @@ export const CarouselStatic = forwardRef(function CarouselStatic(
 
   if (products.length === 0) {
     return (
-      <div className={cn(className, 'w-full bg-gray-100 p-6 text-center')}>
+      <div className={cn(className, 'w-full bg-gray-100 text-center')}>
         No products have been added
       </div>
     );
   }
 
   return (
-    <Carousel aria-labelledby="Carousel" className={cn(className, 'pb-0')} ref={ref}>
+    <Carousel aria-labelledby="Carousel" className={cn(className)} ref={ref}>
       <div className="flex items-center justify-between">
         <h2 className="text-3xl font-black lg:text-4xl" id="title">
           {title}

--- a/components/product-card-carousel/index.tsx
+++ b/components/product-card-carousel/index.tsx
@@ -44,7 +44,7 @@ export const ProductCardCarousel = ({
   }, []);
 
   return (
-    <Carousel aria-labelledby="title" className="mb-14">
+    <Carousel aria-labelledby="title">
       <div className="flex items-center justify-between">
         <h2 className="text-3xl font-black lg:text-4xl" id="title">
           {title}

--- a/components/product-carousel/product-carousel.makeswift.ts
+++ b/components/product-carousel/product-carousel.makeswift.ts
@@ -1,4 +1,4 @@
-import { Combobox, TextInput } from '@makeswift/runtime/controls';
+import { Combobox, Style, TextInput } from '@makeswift/runtime/controls';
 import { forwardNextDynamicRef } from '@makeswift/runtime/next';
 import dynamic from 'next/dynamic';
 
@@ -21,6 +21,7 @@ const fetchCategories = async (): Promise<Category[]> => {
 
 export const props = {
   title: TextInput({ label: 'Title', defaultValue: 'Products', selectAll: true }),
+  className: Style(),
   categoryId: Combobox({
     label: 'Category',
     async getOptions(query) {

--- a/components/product-carousel/product-carousel.tsx
+++ b/components/product-carousel/product-carousel.tsx
@@ -19,6 +19,7 @@ import { Product, ProductCard } from './product-card';
 interface Props {
   title: string;
   categoryId?: number;
+  className?: string;
 }
 
 type QuickSearchResults = Awaited<ReturnType<typeof getQuickSearchResults>>;
@@ -41,82 +42,84 @@ export const fetchQuickSearch = async ({ categoryId }: { categoryId?: number }) 
   }));
 };
 
-export const ProductCardCarousel = forwardRef<HTMLElement, Props>(({ title, categoryId }, ref) => {
-  const id = useId();
-  const deferredQuery = useDeferredValue({ categoryId });
+export const ProductCardCarousel = forwardRef<HTMLElement, Props>(
+  ({ title, categoryId, className }, ref) => {
+    const id = useId();
+    const deferredQuery = useDeferredValue({ categoryId });
 
-  const { data: products = [], isLoading } = useQuery({
-    queryKey: ['quick-search-product-carousel', deferredQuery],
-    queryFn: () => fetchQuickSearch(deferredQuery),
-    enabled: !!categoryId,
-  });
+    const { data: products = [], isLoading } = useQuery({
+      queryKey: ['quick-search-product-carousel', deferredQuery],
+      queryFn: () => fetchQuickSearch(deferredQuery),
+      enabled: !!categoryId,
+    });
 
-  if (products.length === 0) {
+    if (products.length === 0) {
+      return (
+        <Carousel aria-labelledby="title" className={className} ref={ref}>
+          <div className="flex items-center justify-between">
+            <h2 className="text-3xl font-black lg:text-4xl" id="title">
+              {title}
+            </h2>
+            <span className="no-wrap flex">
+              <CarouselPreviousIndicator className="opacity-20" disabled />
+              <CarouselNextIndicator className="opacity-20" disabled />
+            </span>
+          </div>
+          <div className="mt-5 flex min-h-48 w-full items-center justify-center gap-4 lg:mt-6">
+            {isLoading ? (
+              <>
+                <DummyCard />
+                <DummyCard />
+                <DummyCard />
+                <DummyCard />
+              </>
+            ) : (
+              <span className="text-lg opacity-20">Category has no products</span>
+            )}
+          </div>
+        </Carousel>
+      );
+    }
+
+    const groupedProducts = products.reduce<Array<Array<Partial<Product>>>>((batches, _, index) => {
+      if (index % 4 === 0) {
+        batches.push([]);
+      }
+
+      const product = products[index];
+
+      if (batches[batches.length - 1] && product) {
+        batches[batches.length - 1]?.push(product);
+      }
+
+      return batches;
+    }, []);
+
     return (
-      <Carousel aria-labelledby="title" className="mb-14 w-full" ref={ref}>
+      <Carousel aria-labelledby="title" className="mb-14" ref={ref}>
         <div className="flex items-center justify-between">
           <h2 className="text-3xl font-black lg:text-4xl" id="title">
             {title}
           </h2>
           <span className="no-wrap flex">
-            <CarouselPreviousIndicator className="opacity-20" disabled />
-            <CarouselNextIndicator className="opacity-20" disabled />
+            <CarouselPreviousIndicator />
+            <CarouselNextIndicator />
           </span>
         </div>
-        <div className="mt-5 flex min-h-48 w-full items-center justify-center gap-4 lg:mt-6">
-          {isLoading ? (
-            <>
-              <DummyCard />
-              <DummyCard />
-              <DummyCard />
-              <DummyCard />
-            </>
-          ) : (
-            <span className="text-lg opacity-20">Category has no products</span>
-          )}
-        </div>
+        <CarouselContent>
+          {products.map((product, index) => (
+            <CarouselSlide
+              aria-label={`${index + 1} of ${groupedProducts.length}`}
+              id={`${id}-slide-${index + 1}`}
+              index={index}
+              key={index}
+            >
+              <ProductCard imageSize="tall" key={product.entityId} product={product} />
+            </CarouselSlide>
+          ))}
+        </CarouselContent>
+        <Pagination groupedProducts={groupedProducts} id={id} />
       </Carousel>
     );
-  }
-
-  const groupedProducts = products.reduce<Array<Array<Partial<Product>>>>((batches, _, index) => {
-    if (index % 4 === 0) {
-      batches.push([]);
-    }
-
-    const product = products[index];
-
-    if (batches[batches.length - 1] && product) {
-      batches[batches.length - 1]?.push(product);
-    }
-
-    return batches;
-  }, []);
-
-  return (
-    <Carousel aria-labelledby="title" className="mb-14" ref={ref}>
-      <div className="flex items-center justify-between">
-        <h2 className="text-3xl font-black lg:text-4xl" id="title">
-          {title}
-        </h2>
-        <span className="no-wrap flex">
-          <CarouselPreviousIndicator />
-          <CarouselNextIndicator />
-        </span>
-      </div>
-      <CarouselContent>
-        {products.map((product, index) => (
-          <CarouselSlide
-            aria-label={`${index + 1} of ${groupedProducts.length}`}
-            id={`${id}-slide-${index + 1}`}
-            index={index}
-            key={index}
-          >
-            <ProductCard imageSize="tall" key={product.entityId} product={product} />
-          </CarouselSlide>
-        ))}
-      </CarouselContent>
-      <Pagination groupedProducts={groupedProducts} id={id} />
-    </Carousel>
-  );
-});
+  },
+);

--- a/components/ui/carousel/carousel.tsx
+++ b/components/ui/carousel/carousel.tsx
@@ -25,7 +25,7 @@ const Carousel = forwardRef<ElementRef<'section'>, ComponentPropsWithRef<'sectio
       <CarouselContext.Provider value={[emblaRef, emblaApi]}>
         <section
           aria-roledescription="carousel"
-          className={cn('relative overflow-x-hidden pb-16', className)}
+          className={cn('relative overflow-x-hidden', className)}
           ref={ref}
           {...props}
         >


### PR DESCRIPTION
Better to diff this one without whitespace: https://github.com/makeswift/catalyst-demo/pull/4/files?w=1

Remove default Product/+Carousel padding, bind `Style` control to Product/+Carousel component